### PR TITLE
Adjust unit test commands 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Building, testing, and packing use all the standard dotnet commands:
 
     dotnet restore
     dotnet build --no-restore
-    dotnet pack
+    dotnet pack -c Debug
     dotnet test --no-build /p:CollectCoverage=true /p:Include=\"[coverlet.collector]*,[coverlet.core]*,[coverlet.msbuild.tasks]*\" /p:Exclude=\"[coverlet.core.tests.samples.netstandard]*,[coverlet.tests.xunit.extensions]*\"
 
 NB. You need to `pack` before testing because we have some integration testing that consume packages


### PR DESCRIPTION
due to changes noted here: https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/dotnet-pack-config, I have made adjustment to the ```dotnet pack``` command to place artifacts in the debug folder which Coverlet's unit tests were originally designed for